### PR TITLE
Export the interfaces as well

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "overridable-fn",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Simple utility to define functions whose behavior can be overriden at runtime",
   "author": "Lorefnon <lorefnon@tutanota.com> (https://lorefnon.me)",
   "main": "index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,8 @@
-interface FnImpl<TArgs extends any[], TRet> {
+export interface FnImpl<TArgs extends any[], TRet> {
     (...args: TArgs): TRet;
 }
 
-interface WrappedFnImpl<TArgs extends any[], TRet> {
+export interface WrappedFnImpl<TArgs extends any[], TRet> {
     (...args: TArgs): TRet;
     unwrap: () => FnImpl<TArgs, TRet>;
     override: (


### PR DESCRIPTION
Currently this module is not exporting the interfaces used, which causes errors like: `Exported variable ... has or is using name 'WrappedFnImpl' from external module "..../node_modules/overridable-fn/dist/index" but cannot be named.` when declarations are being emitted.